### PR TITLE
Add support for multipart form data and file uploads.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='shellfire',
-    version='0.8.2',
+    version='0.9',
     description=(
         'shellfire is an exploitation shell focusing on exploiting command '
         'injection vulnerabilities, eg., LFI, RFI, SSTI, etc.'

--- a/shellfire/__init__.py
+++ b/shellfire/__init__.py
@@ -26,7 +26,7 @@ if (sys.version_info < (3, 0)):
 ## Parse options
 
 parser = argparse.ArgumentParser(
-    description='Exploitation shell for LFI/RFI and command injection')
+    description='An exploitation shell for command injection vulnerabilities.')
 parser.add_argument('-c',
                     dest='config',
                     action='store',

--- a/shellfire/config.py
+++ b/shellfire/config.py
@@ -12,6 +12,7 @@ class Configs():
   cookies: object
   default_headers: object
   encode_chain: List[any]
+  files: dict
   headers: object
   history_file: str
   http_port: Number
@@ -51,6 +52,7 @@ class Configs():
     self.payload_type = "PHP"
     self.encode_chain = []
     self.encode = None
+    self.files = {}
     self.marker = "--9453901401ed3551bc94fcedde066e5fa5b81b7ff878c18c957655206fd538da--"
     self.http_port = 8888
 


### PR DESCRIPTION
Now, we can specify `.method form` for multipart form data, and we can specify files to upload with it. There are two ways we can do this:
* specify `@filename` to upload a raw file.
* specify the name of a plugin to use to generate the file upload content.